### PR TITLE
fix(security): address CodeQL alerts (insecure randomness + workflow permissions)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,11 @@ on:
     branches: [main]
   workflow_dispatch:
 
+# Least privilege: this workflow only SSHes out to the server and never
+# calls the GitHub API, so GITHUB_TOKEN needs no write scopes.
+permissions:
+  contents: read
+
 concurrency:
   group: deploy-app
   cancel-in-progress: false

--- a/hooks/useUserId.ts
+++ b/hooks/useUserId.ts
@@ -1,11 +1,15 @@
 import { useEffect, useState } from 'react';
 import AsyncStorage from '@react-native-async-storage/async-storage';
+import * as Crypto from 'expo-crypto';
 
 const STORAGE_KEY = 'jimi.userId';
 const subscribers = new Set<(id: string) => void>();
 
+// Cryptographically secure id (UUID v4). Math.random() is not a CSPRNG
+// and was flagged by CodeQL — expo-crypto uses the platform's secure RNG
+// (Web Crypto on web, native SecRandom/SecureRandom on iOS/Android).
 function generateUserId(): string {
-  return Math.floor(Math.random() * 100000).toString();
+  return Crypto.randomUUID();
 }
 
 // Generates a brand-new userId, persists it, and notifies every live

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@react-navigation/native": "^6.1.18",
         "expo": "^55.0.18",
         "expo-constants": "~55.0.15",
+        "expo-crypto": "~55.0.15",
         "expo-font": "~55.0.6",
         "expo-linking": "~55.0.14",
         "expo-router": "~55.0.13",
@@ -3711,6 +3712,15 @@
       "peerDependencies": {
         "expo": "*",
         "react-native": "*"
+      }
+    },
+    "node_modules/expo-crypto": {
+      "version": "55.0.15",
+      "resolved": "https://registry.npmjs.org/expo-crypto/-/expo-crypto-55.0.15.tgz",
+      "integrity": "sha512-nlxLguQyJM4MhDDERL30WZkq68/BujOcAp4QdGk+1pZmUmG1p2M8cF7GeFwYvWwjH0DVsIRtRh4ukeTvOZVTPg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "expo": "*"
       }
     },
     "node_modules/expo-file-system": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@react-navigation/native": "^6.1.18",
     "expo": "^55.0.18",
     "expo-constants": "~55.0.15",
+    "expo-crypto": "~55.0.15",
     "expo-font": "~55.0.6",
     "expo-linking": "~55.0.14",
     "expo-router": "~55.0.13",


### PR DESCRIPTION
## Contexte

Corrige les 2 alertes **CodeQL** (code scanning) encore ouvertes sur `main`. Elles auraient dû partir avec la #4 mais le commit correspondant a été poussé **après** le merge squash (qui n'a embarqué que les fixes de dépendances) — d'où cette PR de rattrapage.

| # | Alerte | Sévérité | Fix |
|---|---|---|---|
| 2 | Insecure randomness (`hooks/useUserId.ts`) | High | `Math.random()` → `expo-crypto` `randomUUID()` (CSPRNG : Web Crypto sur web, RNG natif sécurisé sur iOS/Android) |
| 1 | Workflow does not contain permissions (`.github/workflows/deploy.yml`) | Medium | Ajout `permissions: contents: read` (moindre privilège ; le workflow ne fait que du SSH sortant) |

## Notes

- Les `userId` déjà persistés en AsyncStorage ne changent pas ; seul le format des **nouveaux** ids passe de numérique à UUID (traité comme opaque côté backend).
- `expo-crypto@~55.0.15` ajouté (package first-party Expo).

## Vérifications

- `npm run typecheck` ✅
- `npm run build:web` ✅ (validé lors de la #4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)