### PR TITLE
feat(calendar): multi-provider connect — Google, Microsoft, CalDAV (app)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,13 +39,14 @@ jimi_app/
 ├── api/
 │   ├── constants.ts            # baseUrl + endpoint paths
 │   ├── apiServicePost.ts       # POST /chat + POST /chat/confirm clients
-│   ├── calendarConnection.ts   # OAuth connect + GET/DELETE /connections
+│   ├── calendarConnection.ts   # multi-provider connect (OAuth + CalDAV) + GET/DELETE /connections
 │   ├── nativeCalendar.ts       # deep-link into the device calendar app
 │   └── healthcheck.ts          # /chat probe used at startup
 ├── components/
 │   ├── AppBar.tsx              # logo + status pill + calendar/info buttons
 │   ├── ChatBubble.tsx          # one message bubble (uses RichText for bot)
 │   ├── ChatActions.tsx         # inline buttons: connect / confirm / open event
+│   ├── ConnectCalendarSheet.tsx# provider picker (Google/Microsoft OAuth + CalDAV form)
 │   ├── RichText.tsx            # markdown-lite renderer (**bold**, bullets…)
 │   ├── EmptyChat.tsx           # initial state w/ suggestions
 │   ├── TypingIndicator.tsx     # 3-dot animation while waiting for /chat
@@ -91,8 +92,16 @@ returns
 Status drives the inline action attached to the bot bubble (see
 `components/ChatActions.tsx` + `toBotMessage` in `home.tsx`):
 - `AWAITING_INFO` → keep `conversationId`, ask for the missing fields.
-- `NEEDS_CONNECTION` → show "Connect Google Calendar" (OAuth via
-  `api/calendarConnection.ts`); on success the triggering message is replayed.
+- `NEEDS_CONNECTION` → show a single "Connect a calendar" button that opens a
+  provider picker (`components/ConnectCalendarSheet.tsx`):
+    - **Google Calendar** / **Outlook / Microsoft 365** → OAuth in a browser
+      session (`connectOAuth(userId, provider)`), then poll `/connections`.
+    - **Apple iCloud / Other (CalDAV)** → a credentials form (server URL,
+      username, app-specific password) that POSTs to `/connect/caldav`
+      (`connectCalDav`) and shows inline errors on failure.
+  On any success the picker closes, a "calendar connected" bot message is
+  posted, and the triggering message is replayed (`finishConnect` in
+  `home.tsx`).
 - `AWAITING_CONFIRMATION` → show Confirm/Cancel; they call
   `POST /chat/confirm { userId, conversationId, confirmed }`. The
   `conversationId` lives in the message action, NOT in the shared ref, so

--- a/api/calendarConnection.ts
+++ b/api/calendarConnection.ts
@@ -1,12 +1,35 @@
 import * as WebBrowser from 'expo-web-browser';
 import { ApiConstants } from './constants';
 
-// Manages linking the user's real calendar (Google for now) and checking
-// connection status. No calendar content is fetched here — JIMI reads/writes
-// the calendar live on the server side; the app only triggers OAuth and asks
-// "which providers are connected?".
+// Manages linking the user's real calendar and checking connection status.
+// No calendar content is fetched here — JIMI reads/writes the calendar live on
+// the server side; the app only triggers the connect flow and asks "which
+// providers are connected?".
+//
+// Two connect shapes:
+//   - OAuth  (Google, Microsoft) → open the provider consent screen in a
+//     secure browser session, then poll /connections (the server records the
+//     account during the OAuth callback).
+//   - CalDAV (Apple iCloud / other) → POST credentials directly; the server
+//     validates them and replies synchronously, so no polling is needed.
 
 const RETURN_URL = 'jimi://connected';
+
+// OAuth providers. CalDAV is intentionally excluded — it has a different,
+// credentials-based flow and is handled by `connectCalDav`.
+export type OAuthProvider = 'google' | 'microsoft';
+export type CalendarProvider = OAuthProvider | 'caldav';
+
+export interface CalDavCredentials {
+  serverUrl: string;
+  username: string;
+  password: string;
+}
+
+export interface CalDavResult {
+  ok: boolean;
+  reason?: string;
+}
 
 export async function fetchConnectedProviders(userId: string): Promise<string[]> {
   const url = `${ApiConstants.baseUrl}${ApiConstants.connections}?userId=${encodeURIComponent(userId)}`;
@@ -23,12 +46,15 @@ export async function isCalendarConnected(userId: string): Promise<boolean> {
   return (await fetchConnectedProviders(userId)).length > 0;
 }
 
-// Opens Google's consent screen in a secure auth session, then verifies the
-// link by polling /connections (the server records the account during the
-// OAuth callback). Returns true once the calendar is connected.
-export async function connectGoogle(userId: string): Promise<boolean> {
+// Opens the provider's consent screen in a secure auth session, then verifies
+// the link by polling /connections. Returns true once the calendar is
+// connected. Shared by Google and Microsoft — only the path differs.
+export async function connectOAuth(
+  userId: string,
+  provider: OAuthProvider,
+): Promise<boolean> {
   const authUrl =
-    `${ApiConstants.baseUrl}${ApiConstants.connectGoogle}?userId=${encodeURIComponent(userId)}`;
+    `${ApiConstants.baseUrl}${ApiConstants.connect(provider)}?userId=${encodeURIComponent(userId)}`;
   try {
     await WebBrowser.openAuthSessionAsync(authUrl, RETURN_URL);
   } catch {
@@ -38,9 +64,35 @@ export async function connectGoogle(userId: string): Promise<boolean> {
   return pollConnected(userId);
 }
 
-export async function disconnectGoogle(userId: string): Promise<void> {
+// CalDAV uses credentials instead of OAuth: POST them and trust the server's
+// synchronous verdict. Returns `{ ok }` plus a human-readable `reason` on
+// failure so the form can surface it inline.
+export async function connectCalDav(
+  userId: string,
+  credentials: CalDavCredentials,
+): Promise<CalDavResult> {
+  const url = `${ApiConstants.baseUrl}${ApiConstants.connectCalDav}`;
+  try {
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({ userId, ...credentials }),
+    });
+    if (res.ok) {
+      const json = (await res.json().catch(() => null)) as { connected?: unknown } | null;
+      return { ok: json?.connected === true };
+    }
+    const err = (await res.json().catch(() => null)) as { reason?: unknown } | null;
+    const reason = typeof err?.reason === 'string' ? err.reason : undefined;
+    return { ok: false, reason };
+  } catch {
+    return { ok: false, reason: 'Network error — check the server URL and your connection.' };
+  }
+}
+
+export async function disconnect(userId: string, provider: CalendarProvider): Promise<void> {
   const url =
-    `${ApiConstants.baseUrl}${ApiConstants.connectGoogle}?userId=${encodeURIComponent(userId)}`;
+    `${ApiConstants.baseUrl}${ApiConstants.connect(provider)}?userId=${encodeURIComponent(userId)}`;
   await fetch(url, { method: 'DELETE' });
 }
 

--- a/api/constants.ts
+++ b/api/constants.ts
@@ -27,5 +27,11 @@ export const ApiConstants = {
   sendMessage: '/chat',
   confirm: '/chat/confirm',
   connections: '/connections',
+  // OAuth providers share the same /connect/{provider} shape; CalDAV is a
+  // dedicated credentials POST. `connect(provider)` builds the path so callers
+  // never hardcode it.
+  connect: (provider: string) => `/connect/${provider}`,
   connectGoogle: '/connect/google',
+  connectMicrosoft: '/connect/microsoft',
+  connectCalDav: '/connect/caldav',
 } as const;

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -29,8 +29,14 @@ import {
   typography,
 } from '../theme/styles';
 import { ChatActions } from '../components/ChatActions';
+import { ConnectCalendarSheet } from '../components/ConnectCalendarSheet';
 import { sendMessage, confirmAction } from '../api/apiServicePost';
-import { connectGoogle } from '../api/calendarConnection';
+import {
+  connectOAuth,
+  connectCalDav,
+  type CalDavCredentials,
+  type OAuthProvider,
+} from '../api/calendarConnection';
 import { openEvent } from '../api/nativeCalendar';
 import { ChatApiResponse, MessageModel } from '../models/Message';
 import { useApiHealth } from '../contexts/ApiHealthContext';
@@ -55,6 +61,13 @@ export default function ChatScreen() {
   const [pending, setPending] = useState(false);
   const conversationIdRef = useRef<string | null>(null);
   const listRef = useRef<FlatList<MessageModel>>(null);
+  // When a 'connect' action is tapped we open the provider picker; the index
+  // and retryMessage of the originating action are kept so success can consume
+  // that action and replay the original message.
+  const [connectSheet, setConnectSheet] = useState<{
+    index: number;
+    retryMessage?: string;
+  } | null>(null);
   const userId = useUserId();
 
   const { status, errorReason, recheck, reportFailure } = useApiHealth();
@@ -121,27 +134,43 @@ export default function ChatScreen() {
     ]);
   }, []);
 
-  const handleConnect = useCallback(
-    async (index: number, retryMessage?: string) => {
-      if (!userId) return;
-      const connected = await connectGoogle(userId);
-      consumeAction(index);
-      if (connected) {
-        appendBot('Your calendar is connected. 🎉');
-        if (retryMessage) submit(retryMessage);
-      } else {
-        setMessages((prev) => [
-          ...prev,
-          {
-            content: "I couldn't confirm the connection. Want to try again?",
-            sender: 'Chatbot',
-            timestamp: Date.now(),
-            action: { kind: 'connect', retryMessage },
-          },
-        ]);
-      }
+  // Tapping the inline 'Connect a calendar' button no longer runs Google
+  // directly — it opens the provider picker. The picker reports success and we
+  // finish the flow here (consume the action, confirm, replay the message).
+  const openConnectSheet = useCallback((index: number, retryMessage?: string) => {
+    setConnectSheet({ index, retryMessage });
+  }, []);
+
+  const finishConnect = useCallback(() => {
+    if (connectSheet) {
+      consumeAction(connectSheet.index);
+      appendBot('Your calendar is connected. \u{1F389}');
+      if (connectSheet.retryMessage) submit(connectSheet.retryMessage);
+    }
+    setConnectSheet(null);
+  }, [connectSheet, consumeAction, appendBot, submit]);
+
+  // OAuth providers (Google, Microsoft): on success we close the sheet and run
+  // finishConnect. On failure we return false so the sheet shows its own retry
+  // hint and stays open.
+  const handleConnectOAuth = useCallback(
+    async (provider: OAuthProvider): Promise<boolean> => {
+      if (!userId) return false;
+      const ok = await connectOAuth(userId, provider);
+      if (ok) finishConnect();
+      return ok;
     },
-    [userId, consumeAction, appendBot, submit],
+    [userId, finishConnect],
+  );
+
+  const handleConnectCalDav = useCallback(
+    async (credentials: CalDavCredentials) => {
+      if (!userId) return { ok: false, reason: 'Not signed in yet.' };
+      const result = await connectCalDav(userId, credentials);
+      if (result.ok) finishConnect();
+      return result;
+    },
+    [userId, finishConnect],
   );
 
   const handleConfirm = useCallback(
@@ -170,7 +199,7 @@ export default function ChatScreen() {
         {item.action ? (
           <ChatActions
             action={item.action}
-            onConnect={() => handleConnect(index, item.action?.retryMessage)}
+            onConnect={() => openConnectSheet(index, item.action?.retryMessage)}
             onConfirm={(confirmed) =>
               item.action?.conversationId
                 ? handleConfirm(index, item.action.conversationId, confirmed)
@@ -332,6 +361,12 @@ export default function ChatScreen() {
             </View>
           </View>
         </KeyboardAvoidingView>
+        <ConnectCalendarSheet
+          visible={connectSheet !== null}
+          onClose={() => setConnectSheet(null)}
+          onConnectOAuth={handleConnectOAuth}
+          onConnectCalDav={handleConnectCalDav}
+        />
       </View>
     </SafeAreaView>
   );

--- a/components/ChatActions.tsx
+++ b/components/ChatActions.tsx
@@ -30,7 +30,7 @@ export function ChatActions({ action, onConnect, onConfirm, onOpenEvent }: Props
     return (
       <View style={styles.wrap}>
         <Button
-          label="Connect Google Calendar"
+          label="Connect a calendar"
           variant="primary"
           busy={busy}
           onPress={() => run(() => onConnect())}

--- a/components/ConnectCalendarSheet.tsx
+++ b/components/ConnectCalendarSheet.tsx
@@ -1,0 +1,428 @@
+import { useCallback, useState } from 'react';
+import {
+  ActivityIndicator,
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  TextInput,
+  View,
+} from 'react-native';
+import { colors, radius, shadow, spacing, typography } from '../theme/styles';
+import type {
+  CalDavCredentials,
+  CalDavResult,
+  OAuthProvider,
+} from '../api/calendarConnection';
+
+interface Props {
+  visible: boolean;
+  onClose: () => void;
+  // Runs the OAuth flow for the chosen provider; resolves true once linked.
+  onConnectOAuth: (provider: OAuthProvider) => Promise<boolean>;
+  // Submits CalDAV credentials; resolves the server verdict.
+  onConnectCalDav: (credentials: CalDavCredentials) => Promise<CalDavResult>;
+}
+
+type View_ = 'picker' | 'caldav';
+
+// Bottom-sheet style picker that lets the user choose which calendar to link.
+// OAuth providers (Google, Microsoft) hand off to a browser session; CalDAV
+// collects credentials inline. On any success the parent closes the sheet and
+// drives the "calendar connected" follow-up, so this component only reports
+// outcomes via the callbacks.
+export function ConnectCalendarSheet({
+  visible,
+  onClose,
+  onConnectOAuth,
+  onConnectCalDav,
+}: Props) {
+  const [view, setView] = useState<View_>('picker');
+  const [busy, setBusy] = useState<OAuthProvider | 'caldav' | null>(null);
+  const [serverUrl, setServerUrl] = useState('');
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+
+  const reset = useCallback(() => {
+    setView('picker');
+    setBusy(null);
+    setServerUrl('');
+    setUsername('');
+    setPassword('');
+    setError(null);
+  }, []);
+
+  const close = useCallback(() => {
+    if (busy) return;
+    reset();
+    onClose();
+  }, [busy, reset, onClose]);
+
+  const handleOAuth = useCallback(
+    async (provider: OAuthProvider) => {
+      if (busy) return;
+      setError(null);
+      setBusy(provider);
+      try {
+        const ok = await onConnectOAuth(provider);
+        if (ok) {
+          reset();
+        } else {
+          setError("We couldn't confirm the connection. Please try again.");
+        }
+      } finally {
+        setBusy(null);
+      }
+    },
+    [busy, onConnectOAuth, reset],
+  );
+
+  const handleCalDav = useCallback(async () => {
+    if (busy) return;
+    if (!serverUrl.trim() || !username.trim() || !password) {
+      setError('Please fill in the server URL, username and password.');
+      return;
+    }
+    setError(null);
+    setBusy('caldav');
+    try {
+      const result = await onConnectCalDav({
+        serverUrl: serverUrl.trim(),
+        username: username.trim(),
+        password,
+      });
+      if (result.ok) {
+        reset();
+      } else {
+        setError(result.reason ?? "Those credentials didn't work. Please double-check them.");
+      }
+    } finally {
+      setBusy(null);
+    }
+  }, [busy, serverUrl, username, password, onConnectCalDav, reset]);
+
+  return (
+    <Modal
+      visible={visible}
+      transparent
+      animationType="slide"
+      onRequestClose={close}
+      statusBarTranslucent
+    >
+      <Pressable style={styles.backdrop} onPress={close} accessibilityLabel="Close" />
+      <KeyboardAvoidingView
+        behavior={Platform.OS === 'ios' ? 'padding' : undefined}
+        style={styles.sheetWrap}
+        pointerEvents="box-none"
+      >
+        <View style={styles.sheet}>
+          <View style={styles.grabber} />
+          {view === 'picker' ? (
+            <ScrollView showsVerticalScrollIndicator={false}>
+              <Text style={styles.title}>Connect a calendar</Text>
+              <Text style={styles.subtitle}>
+                Jimi reads and writes your real calendar. Choose where it lives.
+              </Text>
+
+              <ProviderRow
+                label="Google Calendar"
+                hint="Sign in with your Google account"
+                busy={busy === 'google'}
+                disabled={busy !== null}
+                onPress={() => handleOAuth('google')}
+              />
+              <ProviderRow
+                label="Outlook / Microsoft 365"
+                hint="Sign in with your Microsoft account"
+                busy={busy === 'microsoft'}
+                disabled={busy !== null}
+                onPress={() => handleOAuth('microsoft')}
+              />
+              <ProviderRow
+                label="Apple iCloud / Other (CalDAV)"
+                hint="Connect with a server URL and credentials"
+                busy={false}
+                disabled={busy !== null}
+                onPress={() => {
+                  setError(null);
+                  setView('caldav');
+                }}
+              />
+
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+            </ScrollView>
+          ) : (
+            <ScrollView showsVerticalScrollIndicator={false} keyboardShouldPersistTaps="handled">
+              <Text style={styles.title}>Apple iCloud / CalDAV</Text>
+              <Text style={styles.subtitle}>
+                Enter your CalDAV server and credentials. For iCloud, use an
+                app-specific password generated at appleid.apple.com (your normal
+                password won't work).
+              </Text>
+
+              <Field
+                label="Server URL"
+                value={serverUrl}
+                onChangeText={setServerUrl}
+                placeholder="https://caldav.icloud.com"
+                keyboardType="url"
+                autoCapitalize="none"
+                editable={!busy}
+              />
+              <Field
+                label="Username / email"
+                value={username}
+                onChangeText={setUsername}
+                placeholder="you@icloud.com"
+                keyboardType="email-address"
+                autoCapitalize="none"
+                editable={!busy}
+              />
+              <Field
+                label="App-specific password"
+                value={password}
+                onChangeText={setPassword}
+                placeholder="xxxx-xxxx-xxxx-xxxx"
+                autoCapitalize="none"
+                secureTextEntry
+                editable={!busy}
+              />
+
+              {error ? <Text style={styles.error}>{error}</Text> : null}
+
+              <View style={styles.formActions}>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Back to provider list"
+                  disabled={busy !== null}
+                  onPress={() => {
+                    setError(null);
+                    setView('picker');
+                  }}
+                  style={({ pressed }) => [
+                    styles.button,
+                    styles.ghost,
+                    pressed && busy === null && styles.pressed,
+                    busy !== null && styles.disabled,
+                  ]}
+                >
+                  <Text style={[styles.buttonLabel, styles.ghostLabel]}>Back</Text>
+                </Pressable>
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Connect CalDAV calendar"
+                  disabled={busy !== null}
+                  onPress={handleCalDav}
+                  style={({ pressed }) => [
+                    styles.button,
+                    styles.primary,
+                    styles.grow,
+                    pressed && busy === null && styles.pressed,
+                    busy !== null && styles.disabled,
+                  ]}
+                >
+                  {busy === 'caldav' ? (
+                    <ActivityIndicator size="small" color={colors.surface} />
+                  ) : (
+                    <Text style={[styles.buttonLabel, styles.primaryLabel]}>Connect</Text>
+                  )}
+                </Pressable>
+              </View>
+            </ScrollView>
+          )}
+        </View>
+      </KeyboardAvoidingView>
+    </Modal>
+  );
+}
+
+function ProviderRow({
+  label,
+  hint,
+  busy,
+  disabled,
+  onPress,
+}: {
+  label: string;
+  hint: string;
+  busy: boolean;
+  disabled: boolean;
+  onPress: () => void;
+}) {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={label}
+      disabled={disabled}
+      onPress={onPress}
+      style={({ pressed }) => [
+        styles.row,
+        pressed && !disabled && styles.pressed,
+        disabled && !busy && styles.disabled,
+      ]}
+    >
+      <View style={styles.rowText}>
+        <Text style={styles.rowLabel}>{label}</Text>
+        <Text style={styles.rowHint}>{hint}</Text>
+      </View>
+      {busy ? (
+        <ActivityIndicator size="small" color={colors.accent} />
+      ) : (
+        <Text style={styles.chevron}>›</Text>
+      )}
+    </Pressable>
+  );
+}
+
+function Field({
+  label,
+  ...input
+}: {
+  label: string;
+} & React.ComponentProps<typeof TextInput>) {
+  return (
+    <View style={styles.field}>
+      <Text style={styles.fieldLabel}>{label}</Text>
+      <TextInput
+        style={styles.fieldInput}
+        placeholderTextColor={colors.hint}
+        accessibilityLabel={label}
+        {...input}
+      />
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  backdrop: {
+    ...StyleSheet.absoluteFillObject,
+    backgroundColor: 'rgba(0,0,0,0.35)',
+  },
+  sheetWrap: {
+    flex: 1,
+    justifyContent: 'flex-end',
+  },
+  sheet: {
+    backgroundColor: colors.surface,
+    borderTopLeftRadius: radius.xl,
+    borderTopRightRadius: radius.xl,
+    paddingHorizontal: spacing.lg,
+    paddingTop: spacing.sm,
+    paddingBottom: spacing.xl,
+    maxHeight: '88%',
+    width: '100%',
+    alignSelf: 'center',
+    maxWidth: 720,
+    ...shadow.lg,
+  },
+  grabber: {
+    alignSelf: 'center',
+    width: 40,
+    height: 4,
+    borderRadius: radius.pill,
+    backgroundColor: colors.border,
+    marginBottom: spacing.md,
+  },
+  title: {
+    fontFamily: typography.brandFamily,
+    fontSize: typography.title,
+    fontWeight: '700',
+    color: colors.text,
+  },
+  subtitle: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    color: colors.textMuted,
+    marginTop: spacing.xs,
+    marginBottom: spacing.md,
+    lineHeight: 18,
+  },
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.lg,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md,
+    marginBottom: spacing.sm,
+  },
+  rowText: { flex: 1 },
+  rowLabel: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.body,
+    fontWeight: '600',
+    color: colors.text,
+  },
+  rowHint: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    color: colors.textMuted,
+    marginTop: 2,
+  },
+  chevron: {
+    fontSize: 24,
+    color: colors.hint,
+    marginLeft: spacing.sm,
+  },
+  field: { marginBottom: spacing.md },
+  fieldLabel: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    fontWeight: '600',
+    color: colors.text,
+    marginBottom: spacing.xs,
+  },
+  fieldInput: {
+    borderWidth: 1,
+    borderColor: colors.border,
+    borderRadius: radius.md,
+    paddingHorizontal: spacing.md,
+    paddingVertical: Platform.OS === 'ios' ? 12 : 8,
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.body,
+    color: colors.text,
+    backgroundColor: colors.surface,
+  },
+  error: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    color: colors.offline,
+    marginTop: spacing.xs,
+    marginBottom: spacing.sm,
+  },
+  formActions: {
+    flexDirection: 'row',
+    gap: spacing.sm,
+    marginTop: spacing.xs,
+  },
+  button: {
+    paddingVertical: spacing.sm,
+    paddingHorizontal: spacing.md + 2,
+    borderRadius: radius.lg,
+    alignItems: 'center',
+    justifyContent: 'center',
+    minHeight: 44,
+  },
+  grow: { flex: 1 },
+  primary: { backgroundColor: colors.accent },
+  ghost: {
+    backgroundColor: colors.surface,
+    borderWidth: 1,
+    borderColor: colors.border,
+  },
+  pressed: { opacity: 0.8 },
+  disabled: { opacity: 0.6 },
+  buttonLabel: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.body,
+    fontWeight: '600',
+  },
+  primaryLabel: { color: colors.surface },
+  ghostLabel: { color: colors.text },
+});


### PR DESCRIPTION
## What

Lets users connect **more than Google**. The chat's `NEEDS_CONNECTION` action now opens a **provider picker** instead of a single Google button. Stacks on top of `feat/app-calendar-connect-confirm`.

## UX

- The inline bot button now reads **"Connect a calendar"** and opens a bottom-sheet picker with three options:
  - **Google Calendar** → OAuth (browser session, returns to `jimi://connected`, then poll `/connections`).
  - **Outlook / Microsoft 365** → same OAuth flow, parameterized path `/connect/microsoft`.
  - **Apple iCloud / Other (CalDAV)** → an inline credentials form: Server URL, Username/email, App-specific password (`secureTextEntry`). Helper text notes iCloud needs an app-specific password from appleid.apple.com. Submits to `POST /connect/caldav`; surfaces the server's `reason` as an inline error on failure.
- On **any** provider success the sheet closes, a "Your calendar is connected." bot message is posted, and the original `retryMessage` is replayed — identical to the existing single-Google behavior.
- `confirm` / `openEvent` actions are unchanged.

## Code

- `api/calendarConnection.ts`: `connectGoogle` → `connectOAuth(userId, provider: 'google' | 'microsoft')`; new `connectCalDav(userId, creds)` returning `{ ok, reason? }`; `disconnect(userId, provider)`. OAuth keeps the poll-based confirmation.
- `api/constants.ts`: `connect(provider)` path builder + `connectMicrosoft` / `connectCalDav` entries.
- `components/ConnectCalendarSheet.tsx`: new accessible (accessibilityRole/Label) bottom-sheet, themed with existing tokens (`#f8711e` accent).
- `components/ChatActions.tsx`: connect button relabeled, opens the picker.
- `app/home.tsx`: owns picker state + success/replay wiring.
- `CLAUDE.md`: updated for the multi-provider UI.

No new dependencies (reuses `expo-web-browser`). Strict TypeScript, no `any`.

## Verification

- `npm run typecheck` passes (exit 0).
- **Not** verified end-to-end: there's no live backend for Microsoft/CalDAV in this environment. The **Microsoft** and **CalDAV** backends are landing in parallel API PRs — end-to-end requires those merged and configured (OAuth app registration for Microsoft, CalDAV endpoint). Google OAuth uses the same path as before.

## Notes

Base is `feat/app-calendar-connect-confirm` (not merged to main yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)