### PR TITLE
fix(oauth): send app return URL so web calendar connect works

### DIFF
--- a/api/calendarConnection.ts
+++ b/api/calendarConnection.ts
@@ -1,4 +1,5 @@
 import * as WebBrowser from 'expo-web-browser';
+import * as Linking from 'expo-linking';
 import { ApiConstants } from './constants';
 
 // Manages linking the user's real calendar and checking connection status.
@@ -13,7 +14,14 @@ import { ApiConstants } from './constants';
 //   - CalDAV (Apple iCloud / other) → POST credentials directly; the server
 //     validates them and replies synchronously, so no polling is needed.
 
-const RETURN_URL = 'jimi://connected';
+// Where the OAuth callback should bounce the user back to. On native this is
+// the app's custom scheme (jimi://connected); on web it's the app's own https
+// origin (e.g. https://jimi.julsql.fr/connected). We send it to the server so
+// it redirects there — without this the web app got "Safari cannot open
+// jimi://connected" and the connection never confirmed.
+function buildReturnUrl(): string {
+  return Linking.createURL('connected');
+}
 
 // OAuth providers. CalDAV is intentionally excluded — it has a different,
 // credentials-based flow and is handled by `connectCalDav`.
@@ -53,10 +61,12 @@ export async function connectOAuth(
   userId: string,
   provider: OAuthProvider,
 ): Promise<boolean> {
+  const returnUrl = buildReturnUrl();
   const authUrl =
-    `${ApiConstants.baseUrl}${ApiConstants.connect(provider)}?userId=${encodeURIComponent(userId)}`;
+    `${ApiConstants.baseUrl}${ApiConstants.connect(provider)}?userId=${encodeURIComponent(userId)}` +
+    `&returnUrl=${encodeURIComponent(returnUrl)}`;
   try {
-    await WebBrowser.openAuthSessionAsync(authUrl, RETURN_URL);
+    await WebBrowser.openAuthSessionAsync(authUrl, returnUrl);
   } catch {
     // Session may be dismissed without a clean return (esp. on web) — the
     // poll below is the source of truth either way.

--- a/app/connected.tsx
+++ b/app/connected.tsx
@@ -1,0 +1,38 @@
+import { View, Text, StyleSheet } from 'react-native';
+import { colors, spacing, typography } from '../theme/styles';
+
+// Landing page for the web OAuth return (the server redirects the auth popup
+// here after linking a calendar). The auth session usually detects this URL and
+// closes the popup automatically; this screen is the graceful fallback if the
+// popup fully loads it.
+export default function Connected() {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.title}>Calendar connected ✅</Text>
+      <Text style={styles.subtitle}>You can close this tab and return to Jimi.</Text>
+    </View>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    alignItems: 'center',
+    justifyContent: 'center',
+    padding: spacing.lg,
+    backgroundColor: colors.background,
+  },
+  title: {
+    fontFamily: typography.brandFamily,
+    fontSize: typography.title,
+    fontWeight: '600',
+    color: colors.text,
+    marginBottom: spacing.sm,
+  },
+  subtitle: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.body,
+    color: colors.textMuted,
+    textAlign: 'center',
+  },
+});


### PR DESCRIPTION
Front half of the web-OAuth fix (pairs with API #14).

On the **web app**, connecting a calendar opened the consent popup but then hit *"Safari cannot open the page"* and hung on "We couldn't confirm the connection" — because the server bounced back to the **native** deep link `jimi://connected`, which a browser can't open.

## Fix
`connectOAuth` now sends `Linking.createURL('connected')` as `&returnUrl=` (the app's own https origin on web, `jimi://connected` on native) and uses the same value as the auth-session return. The server (API #14) redirects there, so the popup lands back on the app's origin, the session resolves, and the `/connections` poll confirms the link.

Adds a minimal `app/connected.tsx` landing route as a graceful fallback.

`typecheck` green. Needs API #14 deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
