### PR TITLE
feat(calendar): send calendarMode:true to use connected calendars

### DIFF
--- a/api/apiServicePost.ts
+++ b/api/apiServicePost.ts
@@ -5,6 +5,10 @@ interface ChatRequestBody {
   userId: string;
   message: string;
   conversationId: string | null;
+  // This app is the calendar-aware client: opt into connected-calendar mode
+  // (NEEDS_CONNECTION + confirmation). Omitting it would get the API's legacy
+  // local-DB behaviour, reserved for the older deployed apps.
+  calendarMode: true;
 }
 
 interface ConfirmRequestBody {
@@ -33,7 +37,7 @@ export async function sendMessage(
   userId: string,
   conversationId: string | null = null,
 ): Promise<ChatApiResponse> {
-  const body: ChatRequestBody = { userId, message, conversationId };
+  const body: ChatRequestBody = { userId, message, conversationId, calendarMode: true };
   const json = await postApi<unknown>(ApiConstants.sendMessage, body);
   return parseChatResponse(json);
 }


### PR DESCRIPTION
Pairs with API #17 (legacy local-DB mode for older apps). This calendar-aware app opts into calendar mode by sending `calendarMode:true` on `/chat`, so it keeps the connected-calendar experience (NEEDS_CONNECTION + confirmation) instead of falling back to the legacy local-DB behaviour. typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)