### PR TITLE
feat(calendar): open the connected provider's calendar (not always Google)

### DIFF
--- a/api/nativeCalendar.ts
+++ b/api/nativeCalendar.ts
@@ -1,14 +1,22 @@
 import { Platform } from 'react-native';
 import * as Linking from 'expo-linking';
+import { fetchConnectedProviders } from './calendarConnection';
 
 // JIMI deliberately has no in-app calendar view: the user's real calendar is
-// the source of truth, so we deep-link straight into the device's calendar app
-// (native), or open the web calendar in a NEW TAB on web so the JIMI app stays
-// open in the current tab.
+// the source of truth, so we open it directly — the device's calendar app on
+// native, or the connected provider's web calendar in a NEW TAB on web.
 
 const IOS_CALENDAR = 'calshow:'; // opens Apple Calendar at "today"
 const ANDROID_CALENDAR = 'content://com.android.calendar/time/';
-const WEB_CALENDAR = 'https://calendar.google.com';
+
+// Web calendar of each provider, so the icon opens the calendar you connected
+// (not always Google). The browser uses whichever account you're signed into.
+const WEB_CALENDAR: Record<string, string> = {
+  google: 'https://calendar.google.com',
+  microsoft: 'https://outlook.office.com/calendar/',
+  caldav: 'https://www.icloud.com/calendar/', // Apple iCloud (most common CalDAV)
+};
+const DEFAULT_WEB_CALENDAR = WEB_CALENDAR.google;
 
 // Opens a URL externally. On web that means a new browser tab (so the running
 // JIMI app isn't navigated away); on native it hands off to the OS.
@@ -22,10 +30,30 @@ async function openExternal(url: string): Promise<void> {
   await Linking.openURL(url).catch(() => undefined);
 }
 
+// Opens the calendar of the provider the user has connected. On web that's the
+// matching web calendar (Google / Outlook / iCloud); on native it's the device
+// calendar app, which already shows the connected account.
+export async function openConnectedCalendar(userId: string | null): Promise<void> {
+  if (Platform.OS !== 'web') {
+    await openNativeCalendar();
+    return;
+  }
+  let url = DEFAULT_WEB_CALENDAR;
+  if (userId) {
+    try {
+      const providers = await fetchConnectedProviders(userId);
+      const provider = providers.find((p) => WEB_CALENDAR[p]);
+      if (provider) url = WEB_CALENDAR[provider];
+    } catch {
+      // fall back to the default web calendar
+    }
+  }
+  await openExternal(url);
+}
+
 export async function openNativeCalendar(): Promise<void> {
   if (Platform.OS === 'web') {
-    // Web has no native calendar app — open the web calendar in a new tab.
-    await openExternal(WEB_CALENDAR);
+    await openExternal(DEFAULT_WEB_CALENDAR);
     return;
   }
   const target = Platform.OS === 'ios' ? IOS_CALENDAR : ANDROID_CALENDAR;
@@ -33,7 +61,7 @@ export async function openNativeCalendar(): Promise<void> {
     await Linking.openURL(target);
   } catch {
     // Fallback to the web calendar if the native scheme can't be opened.
-    await Linking.openURL(WEB_CALENDAR).catch(() => undefined);
+    await Linking.openURL(DEFAULT_WEB_CALENDAR).catch(() => undefined);
   }
 }
 

--- a/components/AppBar.tsx
+++ b/components/AppBar.tsx
@@ -17,7 +17,8 @@ import {
   typography,
 } from '../theme/styles';
 import { useApiHealth, type ApiStatus } from '../contexts/ApiHealthContext';
-import { openNativeCalendar } from '../api/nativeCalendar';
+import { openConnectedCalendar } from '../api/nativeCalendar';
+import { useUserId } from '../hooks/useUserId';
 
 const LOGO_SIZE = 40;
 
@@ -76,6 +77,7 @@ export function AppBar() {
   const router = useRouter();
   const pathname = usePathname();
   const { status } = useApiHealth();
+  const userId = useUserId();
 
   const onAbout = pathname === '/about';
   // Toggle off → always go straight to the chat, regardless of history.
@@ -86,10 +88,10 @@ export function AppBar() {
       router.push('/about');
     }
   };
-  // No in-app calendar view: open the device's calendar app directly so the
-  // user always sees their real, live calendar (the single source of truth).
+  // No in-app calendar view: open the calendar of the provider the user
+  // connected (Google / Outlook / iCloud on web; the device app on native).
   const handleCalendarPress = () => {
-    void openNativeCalendar();
+    void openConnectedCalendar(userId);
   };
 
   return (


### PR DESCRIPTION
## Today
The AppBar calendar icon always opened **`https://calendar.google.com`** on web, regardless of which calendar you connected.

## Now
It looks up your connected provider via `/connections` and opens the **matching** web calendar:
- google → `calendar.google.com`
- microsoft → `outlook.office.com/calendar`
- caldav → `icloud.com/calendar` (Apple, the common CalDAV case)

The browser opens it with whichever account you're signed into. Native (iOS/Android) still opens the **device calendar app**, which already shows the connected account. Falls back to Google when nothing is connected or the lookup fails.

typecheck green.

> Note: we can't deep-link to a *specific* account email — the minimal `calendar.events` scope doesn't expose it — so it opens the provider's calendar with the browser's signed-in account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)