### PR TITLE
feat(calendar): proactive connect on home + disconnect in About

### DIFF
--- a/app/about.tsx
+++ b/app/about.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import {
   ScrollView,
   View,
@@ -24,6 +24,17 @@ import {
 } from '../theme/styles';
 import { useUserId, resetUserId } from '../hooks/useUserId';
 import { deleteUserData } from '../api/userService';
+import {
+  fetchConnectedProviders,
+  disconnect,
+  type CalendarProvider,
+} from '../api/calendarConnection';
+
+const PROVIDER_LABELS: Record<string, string> = {
+  google: 'Google Calendar',
+  microsoft: 'Outlook / Microsoft 365',
+  caldav: 'Apple iCloud / CalDAV',
+};
 
 const isWeb = Platform.OS === 'web';
 
@@ -80,6 +91,52 @@ function ActionButton({ label, variant = 'ghost', disabled, onPress }: ButtonPro
 export default function AboutScreen() {
   const userId = useUserId();
   const [deleting, setDeleting] = useState(false);
+  const [providers, setProviders] = useState<string[]>([]);
+  const [disconnecting, setDisconnecting] = useState(false);
+
+  useEffect(() => {
+    if (!userId) return;
+    let cancelled = false;
+    fetchConnectedProviders(userId).then((p) => {
+      if (!cancelled) setProviders(p);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  const runDisconnect = async () => {
+    if (!userId || disconnecting || providers.length === 0) return;
+    setDisconnecting(true);
+    try {
+      await Promise.all(providers.map((p) => disconnect(userId, p as CalendarProvider)));
+      setProviders([]);
+      const msg = 'Calendar disconnected.';
+      if (isWeb) window.alert(msg);
+      else Alert.alert('Done', msg);
+    } catch {
+      const msg = 'Could not disconnect. Please try again.';
+      if (isWeb) window.alert(msg);
+      else Alert.alert('Error', msg);
+    } finally {
+      setDisconnecting(false);
+    }
+  };
+
+  const handleDisconnectPress = () => {
+    if (!userId || disconnecting || providers.length === 0) return;
+    const title = 'Disconnect your calendar?';
+    const message =
+      'Jimi will no longer be able to read or write events on your calendar. Your events stay in your calendar.';
+    if (isWeb) {
+      if (window.confirm(`${title}\n\n${message}`)) void runDisconnect();
+    } else {
+      Alert.alert(title, message, [
+        { text: 'Cancel', style: 'cancel' },
+        { text: 'Disconnect', style: 'destructive', onPress: () => void runDisconnect() },
+      ]);
+    }
+  };
 
   const runDeletion = async () => {
     if (!userId || deleting) return;
@@ -183,6 +240,28 @@ export default function AboutScreen() {
             </View>
 
             <View style={styles.ctaSection}>{ctas}</View>
+
+            {providers.length > 0 ? (
+              <View style={styles.calendarSection}>
+                <Text style={styles.sectionTitle}>Connected calendar</Text>
+                <Text style={styles.sectionBody}>
+                  Jimi is connected to{' '}
+                  <Text style={styles.bold}>
+                    {providers.map((p) => PROVIDER_LABELS[p] ?? p).join(', ')}
+                  </Text>
+                  . Disconnecting revokes Jimi&apos;s access; your events stay in
+                  your calendar.
+                </Text>
+                <View style={styles.dangerButtonRow}>
+                  <ActionButton
+                    label={disconnecting ? 'Disconnecting…' : 'Disconnect calendar'}
+                    variant="ghost"
+                    disabled={disconnecting}
+                    onPress={handleDisconnectPress}
+                  />
+                </View>
+              </View>
+            ) : null}
 
             <View style={styles.dangerSection}>
               <Text style={styles.dangerTitle}>Your data</Text>
@@ -327,6 +406,31 @@ const styles = StyleSheet.create({
     marginBottom: spacing.lg,
   },
   dangerButtonRow: { alignItems: 'center' },
+  calendarSection: {
+    marginTop: spacing.xl,
+    padding: spacing.xl,
+    borderRadius: radius.lg,
+    borderWidth: 1,
+    borderColor: colors.border,
+    backgroundColor: colors.surface,
+  },
+  sectionTitle: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    fontWeight: '600',
+    color: colors.accent,
+    letterSpacing: 1,
+    textTransform: 'uppercase',
+    marginBottom: spacing.sm,
+  },
+  sectionBody: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.body,
+    color: colors.text,
+    lineHeight: 22,
+    marginBottom: spacing.lg,
+  },
+  bold: { fontWeight: '600' },
   footer: {
     marginTop: spacing.xl,
     paddingTop: spacing.lg,

--- a/app/home.tsx
+++ b/app/home.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useRef, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useUserId } from '../hooks/useUserId';
 import {
   View,
@@ -34,6 +34,7 @@ import { sendMessage, confirmAction } from '../api/apiServicePost';
 import {
   connectOAuth,
   connectCalDav,
+  isCalendarConnected,
   type CalDavCredentials,
   type OAuthProvider,
 } from '../api/calendarConnection';
@@ -61,19 +62,33 @@ export default function ChatScreen() {
   const [pending, setPending] = useState(false);
   const conversationIdRef = useRef<string | null>(null);
   const listRef = useRef<FlatList<MessageModel>>(null);
-  // When a 'connect' action is tapped we open the provider picker; the index
-  // and retryMessage of the originating action are kept so success can consume
-  // that action and replay the original message.
+  // When a 'connect' action is tapped we open the provider picker. `index` is the
+  // message whose connect button was tapped (so success can consume it); it's
+  // absent when the user connects proactively from the banner.
   const [connectSheet, setConnectSheet] = useState<{
-    index: number;
+    index?: number;
     retryMessage?: string;
   } | null>(null);
+  // null = unknown (not checked yet); true/false once /connections is read.
+  const [calendarConnected, setCalendarConnected] = useState<boolean | null>(null);
   const userId = useUserId();
 
   const { status, errorReason, recheck, reportFailure } = useApiHealth();
   const online = status === 'online';
   const checking = status === 'checking';
   const ready = online && userId !== null;
+
+  // Check whether a calendar is connected, to offer a proactive "connect" CTA.
+  useEffect(() => {
+    if (!userId || !online) return;
+    let cancelled = false;
+    isCalendarConnected(userId).then((c) => {
+      if (!cancelled) setCalendarConnected(c);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [userId, online]);
 
   const submit = useCallback(
     async (text: string) => {
@@ -137,16 +152,17 @@ export default function ChatScreen() {
   // Tapping the inline 'Connect a calendar' button no longer runs Google
   // directly — it opens the provider picker. The picker reports success and we
   // finish the flow here (consume the action, confirm, replay the message).
-  const openConnectSheet = useCallback((index: number, retryMessage?: string) => {
+  const openConnectSheet = useCallback((index?: number, retryMessage?: string) => {
     setConnectSheet({ index, retryMessage });
   }, []);
 
   const finishConnect = useCallback(() => {
     if (connectSheet) {
-      consumeAction(connectSheet.index);
+      if (connectSheet.index !== undefined) consumeAction(connectSheet.index);
       appendBot('Your calendar is connected. \u{1F389}');
       if (connectSheet.retryMessage) submit(connectSheet.retryMessage);
     }
+    setCalendarConnected(true);
     setConnectSheet(null);
   }, [connectSheet, consumeAction, appendBot, submit]);
 
@@ -309,6 +325,23 @@ export default function ChatScreen() {
                 </View>
               ) : null}
 
+              {ready && calendarConnected === false ? (
+                <Pressable
+                  accessibilityRole="button"
+                  accessibilityLabel="Connect a calendar"
+                  onPress={() => openConnectSheet()}
+                  style={({ pressed }) => [
+                    styles.connectBanner,
+                    pressed && styles.connectBannerPressed,
+                  ]}
+                >
+                  <Text style={styles.connectBannerText}>
+                    📅 Connect a calendar to let Jimi manage your events
+                  </Text>
+                  <Text style={styles.connectBannerCta}>Connect →</Text>
+                </Pressable>
+              ) : null}
+
               <View
                 style={[
                   styles.inputBar,
@@ -406,6 +439,32 @@ const styles = StyleSheet.create({
     backgroundColor: colors.background,
   },
   bannerWrap: { marginBottom: spacing.sm },
+  connectBanner: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: spacing.sm,
+    marginBottom: spacing.sm,
+    paddingVertical: spacing.sm + 2,
+    paddingHorizontal: spacing.md,
+    borderRadius: radius.lg,
+    backgroundColor: colors.accentSoft,
+    borderWidth: 1,
+    borderColor: colors.accent,
+  },
+  connectBannerPressed: { opacity: 0.85 },
+  connectBannerText: {
+    flex: 1,
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    color: colors.text,
+  },
+  connectBannerCta: {
+    fontFamily: typography.bodyFamily,
+    fontSize: typography.caption,
+    fontWeight: '700',
+    color: colors.accentDeep,
+  },
   inputBar: {
     flexDirection: 'row',
     alignItems: 'flex-end',


### PR DESCRIPTION
Two UX additions you asked for.

## 1. Connect directly from the home page
On load, the app checks `/connections`. **If no calendar is connected**, a tappable banner appears above the chat input — *"📅 Connect a calendar to let Jimi manage your events — Connect →"* — opening the provider picker (Google / Outlook / Apple-CalDAV) **without having to send a message first**. The connect sheet now also works without an originating chat action.

## 2. Disconnect button in About
A new **"Connected calendar"** section shows which provider is linked, with a **"Disconnect calendar"** button. It revokes Jimi's access (and on Google, the OAuth token) — your events stay in your own calendar. Confirmation prompt before disconnecting.

typecheck green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)