### PR TITLE
chore(gitignore): ignore EAS credentials.json (keystore passwords)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@ yarn-error.log*
 .env
 .env.local
 .env.*.local
+
+# EAS local signing credentials — contains keystore passwords, never commit
+credentials.json


### PR DESCRIPTION
`credentials.json` holds the local Android signing keystore passwords used for EAS local-credential builds — it must never be committed. Add it to `.gitignore`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)