### PR TITLE
ci: notify Keel to redeploy after image push

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -44,3 +44,11 @@ jobs:
             EXPO_PUBLIC_API_URL=https://jimi-api.julsql.fr
           cache-from: type=gha
           cache-to: type=gha,mode=max
+
+      - name: Notify Keel to redeploy
+        run: |
+          curl -fsS --retry 3 --retry-delay 5 -X POST \
+            https://keel.julsql.fr/v1/webhooks/native \
+            -u "${{ secrets.KEEL_WEBHOOK_AUTH }}" \
+            -H 'Content-Type: application/json' \
+            -d '{"name":"ghcr.io/jimidevlab/jimi-app","tag":"latest"}'


### PR DESCRIPTION
## Quoi

Ajoute une étape **Notify Keel** en fin de workflow : après le push GHCR, la CI POST sur le webhook natif de Keel (`https://keel.julsql.fr/v1/webhooks/native`), qui force immédiatement le rollout du Deployment k3s.

## Pourquoi

On abandonne le polling du digest `:latest` par Keel, peu fiable sur les index OCI multi-arch de GHCR (les push réels n'étaient pas détectés). Le webhook est instantané et déterministe. Détails infra : julsql/k3s-manifests#1.

## Prérequis

- Secret GitHub Actions **`KEEL_WEBHOOK_AUTH`** (`user:password`), de préférence au niveau org.
- Endpoint Keel exposé + Secret `keel-webhook-auth` créés (cf. PR k3s).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
